### PR TITLE
fix: charger_temp sensor stuck 'unknown' when tma array has null leading element

### DIFF
--- a/custom_components/wattpilot/entities.py
+++ b/custom_components/wattpilot/entities.py
@@ -539,7 +539,8 @@ class ChargerPlatformEntity(CoordinatorEntity["WattpilotCoordinator"]):
             elif isinstance(state, list):
                 state_list = state
                 if desc.value_id is None:
-                    state = state_list[0]
+                    non_none = [v for v in state_list if v is not None]
+                    state = non_none[0] if non_none else None
                     for i, attr_state in enumerate(state_list[1:], start=1):
                         self._attributes[f"state{i}"] = attr_state
                 else:

--- a/tests/test_coverage_platforms.py
+++ b/tests/test_coverage_platforms.py
@@ -368,6 +368,75 @@ class TestAdditionalEntityEdgeCases:
         assert entity._attributes.get("state1") == "val1"
         assert entity._attributes.get("state2") == "val2"
 
+    @pytest.mark.asyncio
+    async def test_entity_validate_property_list_skips_leading_none(
+        self, mock_hass: HomeAssistant, mock_config_entry: Any, mock_charger: MagicMock
+    ) -> None:
+        """
+        Test validate property with list whose first element is None.
+
+        Reproduces the wattpilot_flex 3-phase 'tma' (charger_temp) property,
+        which reports its leading slot as null (e.g. [None, 23.875, 25.25,
+        25.5, 23.875]). The main state must fall back to the first non-None
+        entry instead of surfacing None as the sensor state.
+        """
+        from custom_components.wattpilot.descriptions import (
+            SOURCE_PROPERTY,
+            WattpilotSensorEntityDescription,
+        )
+        from custom_components.wattpilot.entities import ChargerPlatformEntity
+
+        mock_charger.all_properties = {"test_prop": "test_value"}
+
+        desc = WattpilotSensorEntityDescription(
+            key="test",
+            charger_key="test_prop",
+            name="Test",
+            source=SOURCE_PROPERTY,
+            value_id=None,  # No value_id
+        )
+
+        entity = ChargerPlatformEntity(mock_hass, mock_config_entry, desc, mock_charger)
+
+        state_list = [None, 23.875, 25.25, 25.5, 23.875]
+        result = await entity._async_update_validate_property(state_list)
+
+        # Should skip the leading None and use the first real value
+        assert result == 23.875
+        # Attributes still mirror the raw list from index 1 onward
+        assert entity._attributes.get("state1") == 23.875
+        assert entity._attributes.get("state2") == 25.25
+        assert entity._attributes.get("state3") == 25.5
+        assert entity._attributes.get("state4") == 23.875
+
+    @pytest.mark.asyncio
+    async def test_entity_validate_property_list_all_none(
+        self, mock_hass: HomeAssistant, mock_config_entry: Any, mock_charger: MagicMock
+    ) -> None:
+        """Test validate property with list of all-None entries stays None."""
+        from custom_components.wattpilot.descriptions import (
+            SOURCE_PROPERTY,
+            WattpilotSensorEntityDescription,
+        )
+        from custom_components.wattpilot.entities import ChargerPlatformEntity
+
+        mock_charger.all_properties = {"test_prop": "test_value"}
+
+        desc = WattpilotSensorEntityDescription(
+            key="test",
+            charger_key="test_prop",
+            name="Test",
+            source=SOURCE_PROPERTY,
+            value_id=None,
+        )
+
+        entity = ChargerPlatformEntity(mock_hass, mock_config_entry, desc, mock_charger)
+
+        state_list = [None, None]
+        result = await entity._async_update_validate_property(state_list)
+
+        assert result is None
+
 
 class TestSensorEnumEdgeCases:
     """Test sensor enum handling edge cases."""


### PR DESCRIPTION
## Problem

`sensor.wattpilot_<serial>_charger_temp` (`charger_key: tma`) always reports `unknown`, even though the charger is actively reporting real temperature data.

**Hardware**: Fronius Wattpilot Flex, 22kW, 3-phase (`select.phase_switch` = "3 Phases"), firmware 43.4.

## Evidence — how I found this

Pulled via **Settings → Devices & Services → Fronius Wattpilot → Download Diagnostics** (the same file this repo's bug report template asks reporters to attach), taken twice a few minutes apart on my own charger. Relevant fragment (`data.charger_properties.tma`), rest of the file omitted here since diagnostics redaction misses the LAN IP under `unique_id` and the serial embedded in `charger_info.name` — didn't want to post that unredacted:

Capture 1:
```json
"tma": [null, 23.875, 25.25, 25.5, 23.875]
```
Capture 2 (few minutes later, charger still running):
```json
"tma": [null, null, 38, 43.25, 35.25, 34.875]
```

Two things this shows:
- The main sensor state is always `null` in both captures — confirms the bug is live and current on `master`.
- **The leading run of `null`s isn't fixed at length 1** — 5 elements with 1 leading null in capture 1, 6 elements with 2 leading nulls in capture 2. This is why the fix below skips a leading run of `None`s of any length, rather than assuming a fixed offset.

## Root cause

`entities.py`, `_async_update_validate_property()`:
```python
if desc.value_id is None:
    state = state_list[0]   # always None on this unit -> sensor shows "unknown"
    for i, attr_state in enumerate(state_list[1:], start=1):
        self._attributes[f"state{i}"] = attr_state
```
The real values leak out as `state1`..`state5` attributes (visible only via the more-info dialog), never as the actual sensor state.

## Fix

Pick the first non-`None` entry instead of always index 0:
```python
if desc.value_id is None:
    non_none = [v for v in state_list if v is not None]
    state = non_none[0] if non_none else None
    for i, attr_state in enumerate(state_list[1:], start=1):
        self._attributes[f"state{i}"] = attr_state
```

## Speculation on why the array has a variable-length null lead (unconfirmed — not load-bearing for the fix)

I don't have a spec or vendor doc for why this unit's `tma` array grows a leading `null` run of inconsistent length. One guess I considered: something related to phase count or which physical sensors are currently reporting. **I want to be explicit this is a guess, not a verified fact** — no documentation backs it, I haven't tested on other hardware, and capture 2 above (2 leading nulls vs. 1 in capture 1, same charger, few minutes apart) suggests it isn't even stable per-device, which weakens that guess further. Flagging only in case it's useful context; happy to strip this section if it's unhelpful noise.

The fix doesn't depend on this guess being right — it just stops surfacing `None` as the sensor state whenever the array has any number of leading nulls.

## Blast radius

Checked every `source: property`-equivalent sensor description with no `value_id` set. Of the array-typed protocol properties actually wired to sensors in `descriptions.py` (`cards`, `nrg`, `tma`), only `tma` hits this branch — `cards` uses `SOURCE_NAMESPACELIST` with `value_id="energy"`, `nrg` has `value_id=11` set explicitly. Both take the other branch and are unaffected.

For any list where index 0 is already non-null (e.g. the existing test fixture `tma: [25.5, 26.0]`), `non_none[0] == state_list[0]` — identical output to before. This change only alters behaviour for the specific broken case.

## Testing

- Added `test_entity_validate_property_list_skips_leading_none` — reproduces capture 1 above (`[None, 23.875, 25.25, 25.5, 23.875]`), asserts state resolves to `23.875` instead of `None`.
- Added `test_entity_validate_property_list_all_none` — confirms an all-`None` list still correctly resolves to `None` (no regression for the "not yet initialized" case).
- Full suite: `399 passed` (Python 3.14.6). `ruff check` / `ruff format --check` clean.
- Not tested against a single-phase unit.
