### PR TITLE
Update update.py

### DIFF
--- a/custom_components/wattpilot/update.py
+++ b/custom_components/wattpilot/update.py
@@ -168,7 +168,7 @@ class ChargerUpdate(ChargerPlatformEntity, UpdateEntity):
             return {}
 
     async def async_install(
-        self, version: str | None, *, backup: bool, **kwargs: Any
+        self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Trigger update install."""
         _ = backup


### PR DESCRIPTION
### Description

Triggering a charger **firmware update** fails immediately with:

> Handlingen update/install kunne ikke udføres. ChargerUpdate.async_install() takes 2 positional arguments but 3 were given

The update entity shows a firmware update as available (e.g. installed `42.10`, latest `43.4`), but clicking **Install/Update** always fails.

### Root cause

In `custom_components/wattpilot/update.py`, `ChargerUpdate.async_install()` is declared with `backup` as a **keyword-only** argument:

```python
async def async_install(
    self, version: str | None, *, backup: bool, **kwargs: Any
) -> None:
```

Home Assistant's `UpdateEntity` calls `async_install(version, backup)` **positionally**, so the `*` makes Python reject the call — hence "takes 2 positional arguments but 3 were given". The base class signature is `async def async_install(self, version, backup, **kwargs)`.

### Suggested fix

Remove the `*,` so `backup` is positional:

```python
async def async_install(
    self, version: str | None, backup: bool, **kwargs: Any
) -> None:
```

### Version

- Integration: v2026.6.2
- Home Assistant: (please fill in your HA version — Settings → About)
- Install type: Home Assistant Container (Docker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when initiating charger software updates by allowing the backup option to be provided positionally.
  * Existing update behaviour, validation and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->